### PR TITLE
Gae functional test

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,12 @@ web application directory each time you run this task. This behavior can be chan
 * `gaeUpload`: Uploads files for an application given the application's root directory. The application ID and version are taken from the appengine-web.xml file.
 * `gaeUploadAll`: Uploads your application to App Engine and updates all backends by running the task `gaeUpload` and `gaeUpdateAllBackends`.
 * `gaeVacuumIndexes`: Deletes unused indexes in App Engine server.
+* `gaeFunctionalTest`: Runs the tests from `functionalTest` source set against a local development server started in daemon mode.
 * `gaeVersion`: Prints detailed version information about the SDK, Java and the operating system.
 
 ## Project layout
 
-The GAE plugin uses the same layout as the War plugin.
+The GAE plugin uses the same layout as the War plugin. The only difference is the addition of the `functionalTest` source set (located at 'src/functionalTest' by default) which is used by the `gaeFunctionalTest` task.
 
 ## Convention properties
 

--- a/src/main/groovy/org/gradle/api/plugins/gae/GaePlugin.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/gae/GaePlugin.groovy
@@ -18,8 +18,14 @@ package org.gradle.api.plugins.gae
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.plugins.WarPlugin
-import org.gradle.api.plugins.WarPluginConvention
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.execution.TaskExecutionGraph
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.testing.Test
+import org.gradle.plugins.ide.idea.IdeaPlugin
+import org.gradle.api.plugins.*
 import org.gradle.api.plugins.gae.task.*
 import org.gradle.api.plugins.gae.task.appcfg.*
 import org.gradle.api.plugins.gae.task.appcfg.backends.*
@@ -57,6 +63,7 @@ class GaePlugin implements Plugin<Project> {
     static final String GAE_DELETE_BACKEND = 'gaeDeleteBackend'
     static final String GAE_CONFIGURE_BACKENDS = 'gaeConfigureBackends'
     static final String GAE_UPLOAD_ALL = 'gaeUploadAll'
+    static final String GAE_FUNCTIONAL_TEST = 'gaeFunctionalTest'
     static final String GRADLE_USER_PROP_PASSWORD = 'gaePassword'
     static final String STOP_PORT_CONVENTION_PARAM = 'stopPort'
     static final String STOP_KEY_CONVENTION_PARAM = 'stopKey'
@@ -64,6 +71,9 @@ class GaePlugin implements Plugin<Project> {
     static final String EXPLODED_SDK_DIR_CONVENTION_PARAM = 'explodedSdkDirectory'
     static final String BACKEND_PROJECT_PROPERTY = 'backend'
     static final String SETTING_PROJECT_PROPERTY = 'setting'
+    static final String FUNCTIONAL_TEST_COMPILE_CONFIGURATION = 'functionalTestCompile'
+    static final String FUNCTIONAL_TEST_RUNTIME_CONFIGURATION = 'functionalTestRuntime'
+    static final String FUNCTIONAL_TEST_SOURCE_SET = 'functionalTest'
 
     @Override
     void apply(Project project) {
@@ -107,6 +117,7 @@ class GaePlugin implements Plugin<Project> {
         configureGaeDeleteBackend(project)
         configureGaeConfigureBackends(project)
         configureGaeUploadAll(project)
+        configureGaeFunctionalTest(project, gaePluginConvention)
     }
 
     private File getExplodedSdkDirectory(Project project) {
@@ -391,6 +402,55 @@ class GaePlugin implements Plugin<Project> {
         gaeUploadAllTask.description = 'Uploads your application to App Engine and updates all backends.'
         gaeUploadAllTask.group = GAE_GROUP
         gaeUploadAllTask.dependsOn project.gaeUpload, project.gaeUpdateAllBackends
+    }
+
+    private void configureGaeFunctionalTest(Project project, GaePluginConvention convention) {
+        SourceSet functionalSourceSet = addFunctionalTestConfigurationsAndSourceSet(project)
+
+        Test gaeFunctionalTest = project.tasks.add(GAE_FUNCTIONAL_TEST, Test)
+        gaeFunctionalTest.description = 'Runs functional tests'
+        gaeFunctionalTest.group = GAE_GROUP
+        gaeFunctionalTest.testClassesDir = functionalSourceSet.output.classesDir
+        gaeFunctionalTest.classpath = functionalSourceSet.runtimeClasspath
+        gaeFunctionalTest.dependsOn(project.tasks.getByName(GAE_RUN))
+
+        project.gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
+            if (taskGraph.hasTask(gaeFunctionalTest)) {
+                convention.daemon = true
+            }
+        }
+
+        project.tasks.getByName(JavaBasePlugin.CHECK_TASK_NAME).dependsOn(gaeFunctionalTest)
+    }
+
+    private SourceSet addFunctionalTestConfigurationsAndSourceSet(Project project) {
+        ConfigurationContainer configurations = project.configurations
+        Configuration functionalTestCompileConfiguration = configurations.add(FUNCTIONAL_TEST_COMPILE_CONFIGURATION)
+        Configuration testCompileConfiguration = configurations.getByName(JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME)
+        functionalTestCompileConfiguration.extendsFrom(testCompileConfiguration)
+
+        Configuration functionalTestRuntimeConfiguration = configurations.add(FUNCTIONAL_TEST_RUNTIME_CONFIGURATION)
+        Configuration testRuntimeConfiguration = configurations.getByName(JavaPlugin.TEST_RUNTIME_CONFIGURATION_NAME)
+        functionalTestRuntimeConfiguration.extendsFrom(functionalTestCompileConfiguration, testRuntimeConfiguration)
+
+        SourceSetContainer sourceSets = project.convention.getPlugin(JavaPluginConvention).sourceSets
+        SourceSet functionalSourceSet = sourceSets.add(FUNCTIONAL_TEST_SOURCE_SET)
+        functionalSourceSet.compileClasspath = functionalTestCompileConfiguration
+        functionalSourceSet.runtimeClasspath = functionalSourceSet.output + functionalTestRuntimeConfiguration
+
+        addIdeaConfigurationForFunctionalTestSourceSet(project, functionalTestCompileConfiguration, functionalTestRuntimeConfiguration, functionalSourceSet)
+
+        functionalSourceSet
+    }
+
+    private void addIdeaConfigurationForFunctionalTestSourceSet(Project project, Configuration compile, Configuration runtime, SourceSet sourceSet) {
+        project.plugins.withType(IdeaPlugin) { IdeaPlugin plugin ->
+            plugin.model.module {
+                testSourceDirs += sourceSet.allSource.srcDirs
+                scopes.TEST.plus += compile
+                scopes.TEST.plus += runtime
+            }
+        }
     }
 
     private WarPluginConvention getWarConvention(Project project) {


### PR DESCRIPTION
This pull request brings in a new task - `gaeFunctionalTest`. This task is really simple - it's just a Test task wich runs tests from a new source set (named `functionalTest` and located at `/src/functionalTest` by default) but before execution it also starts the development server in daemon mode making it possible to functionally test the app. This seems to be a common scenario - that's why I see a point in adding it.

Thanks to the task testing with Geb, for example, would be as easy as adding a new dependency:

``` groovy
dependencies 
{
        functionalTestCompile 'org.codehaus.geb:geb-spock:0.7.0', 'org.seleniumhq.selenium:selenium-firefox-driver:2.20.0'
}
```

putting your specs in:
 `src/functionalTest/groovy`

Adding the url to `GebConfig.groovy`:

``` groovy
baseUrl = 'http://localhost:8080/'
```

and running:
`./gradlew gaeFunctionalTest`

There is also integration with the `idea` plugin: if you execute `./gradlew idea` after adding the new dependencies and changing `GebConfig.groovy` you will be able to run your specs directly from your IDE (just rememeber to start the local dev server first in a console).

I will write a blog post about the usage if this gets merged and released.
