### PR TITLE
Fix functionalTest source set dependencies for eclipse projects

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/gae/GaePlugin.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/gae/GaePlugin.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.plugins.*
 import org.gradle.api.plugins.gae.task.*
 import org.gradle.api.plugins.gae.task.appcfg.*
 import org.gradle.api.plugins.gae.task.appcfg.backends.*
+import org.gradle.plugins.ide.eclipse.EclipsePlugin
 
 /**
  * <p>A {@link Plugin} that provides tasks for uploading, running and managing of Google App Engine projects.</p>
@@ -469,6 +470,7 @@ class GaePlugin implements Plugin<Project> {
         functionalSourceSet.runtimeClasspath = functionalSourceSet.output + functionalTestRuntimeConfiguration
 
         addIdeaConfigurationForFunctionalTestSourceSet(project, functionalTestCompileConfiguration, functionalTestRuntimeConfiguration, functionalSourceSet)
+        addEclipseConfigurationForFunctionalTestRuntimeConfiguration(project, functionalTestRuntimeConfiguration)
 
         functionalSourceSet
     }
@@ -480,6 +482,12 @@ class GaePlugin implements Plugin<Project> {
                 scopes.TEST.plus += compile
                 scopes.TEST.plus += runtime
             }
+        }
+    }
+
+    private void addEclipseConfigurationForFunctionalTestRuntimeConfiguration(Project project, Configuration functionalTestRuntimeConfiguration) {
+        project.plugins.withType(EclipsePlugin) { EclipsePlugin plugin ->
+            plugin.model.classpath.plusConfigurations += functionalTestRuntimeConfiguration
         }
     }
 


### PR DESCRIPTION
Fix for an issue reported in: https://groups.google.com/forum/?fromgroups#!topic/gaelyk/cM1arEUaxw0 by adding functionalTestRuntime configuration to eclipse classpath
