### PR TITLE
Fix bug where war explosing is skipped during gaeUpload

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/gae/GaePlugin.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/gae/GaePlugin.groovy
@@ -210,9 +210,6 @@ class GaePlugin implements Plugin<Project> {
         gaeExplodeWarTask.description = 'Explodes WAR archive into directory.'
         gaeExplodeWarTask.group = GAE_GROUP
 
-        // If WAR directory gets set we assume we have a fully functional web application, WAR creation/explosion is skipped
-        gaeExplodeWarTask.onlyIf { !gaePluginConvention.warDir }
-        
         project.afterEvaluate {
             if(isWarOptimizationAllowed(project, gaePluginConvention)) {
                 gaeExplodeWarTask.dependsOn project.slimWar
@@ -242,7 +239,11 @@ class GaePlugin implements Plugin<Project> {
         gaeRunTask.description = 'Starts up a local App Engine development server.'
         gaeRunTask.group = GAE_GROUP
 
-        gaeRunTask.dependsOn project.tasks.getByName(GAE_EXPLODE_WAR)
+        GaeExplodeWarTask gaeExplodeWarTask = project.tasks.getByName(GAE_EXPLODE_WAR)
+        gaeRunTask.dependsOn gaeExplodeWarTask
+
+        // If WAR directory gets set we assume we have a fully functional web application, WAR creation/explosion is skipped
+        gaeExplodeWarTask.onlyIf { !gaePluginConvention.warDir || !project.gradle.taskGraph.hasTask(gaeRunTask) }
     }
 
     private void configureGaeStop(Project project, GaePluginConvention gaePluginConvention) {


### PR DESCRIPTION
Fixes a bug introduced in 0.7.3 where war explosion was skipped when uploading with warDir specified causing build to fail
