### PR TITLE
Added main source set output to functional test classpath

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/gae/GaePlugin.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/gae/GaePlugin.groovy
@@ -31,6 +31,7 @@ import org.gradle.api.plugins.*
 import org.gradle.api.plugins.gae.task.*
 import org.gradle.api.plugins.gae.task.appcfg.*
 import org.gradle.api.plugins.gae.task.appcfg.backends.*
+import static org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 
 /**
  * <p>A {@link Plugin} that provides tasks for uploading, running and managing of Google App Engine projects.</p>
@@ -466,8 +467,9 @@ class GaePlugin implements Plugin<Project> {
         functionalTestRuntimeConfiguration.extendsFrom(functionalTestCompileConfiguration, testRuntimeConfiguration)
 
         SourceSetContainer sourceSets = project.convention.getPlugin(JavaPluginConvention).sourceSets
+        SourceSet mainSourceSet = sourceSets.getByName(MAIN_SOURCE_SET_NAME)
         SourceSet functionalSourceSet = sourceSets.add(FUNCTIONAL_TEST_SOURCE_SET)
-        functionalSourceSet.compileClasspath = functionalTestCompileConfiguration
+        functionalSourceSet.compileClasspath = mainSourceSet.output + functionalTestCompileConfiguration
         functionalSourceSet.runtimeClasspath = functionalSourceSet.output + functionalTestRuntimeConfiguration
 
         addIdeaConfigurationForFunctionalTestSourceSet(project, functionalTestCompileConfiguration, functionalTestRuntimeConfiguration, functionalSourceSet)


### PR DESCRIPTION
That's a thing that I've missed when creating the gaeFunctionalTest stuff. Functional test classes should have access to main application classes and this pull request fixes that. Sorry for yet another bug fixing pull request!
