### PR TITLE
upgrated to latest fatjar plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 dependencies {
     groovy fileTree(dir: new File(gradle.gradleHomeDir, 'lib'), includes: ['**/groovy-all-*.jar'])
     compile gradleApi()
-    compile 'eu.appsatori:gradle-fatjar-plugin:0.1.1', {
+    compile 'eu.appsatori:gradle-fatjar-plugin:0.1.3', {
         ext.optional = true
     }
     testCompile 'org.spockframework:spock-core:0.6-groovy-1.8'


### PR DESCRIPTION
latest version adds support for Groovy 2.0 ext modules, excluding files
from being processed and fixes problem with excluding particular
dependencies from being bundled into the fat jar
